### PR TITLE
Add subtitle field to post schema

### DIFF
--- a/src/sanity/schemaTypes/postType.ts
+++ b/src/sanity/schemaTypes/postType.ts
@@ -8,6 +8,11 @@ export const postType = defineType({
       type: "string",
     }),
     defineField({
+      name: "subtitle",
+      title: "Subtitle",
+      type: "string",
+    }),
+    defineField({
       name: "slug",
       options: {
         source: "title",


### PR DESCRIPTION
Add a new optional 'subtitle' string field to the Sanity postType schema (src/sanity/schemaTypes/postType.ts) so posts can include a subtitle. This extends the content model to support subtitle data alongside the existing title and slug.