### PR TITLE
Wrap NextStudio in fixed full-screen container

### DIFF
--- a/src/app/studio/[[...tool]]/page.tsx
+++ b/src/app/studio/[[...tool]]/page.tsx
@@ -7,13 +7,18 @@
  * https://github.com/sanity-io/next-sanity
  */
 
-import { NextStudio } from 'next-sanity/studio'
-import config from '../../../../sanity.config'
+import { NextStudio } from "next-sanity/studio";
 
-export const dynamic = 'force-static'
+import config from "../../../../sanity.config";
 
-export { metadata, viewport } from 'next-sanity/studio'
+export const dynamic = "force-static";
+
+export { metadata, viewport } from "next-sanity/studio";
 
 export default function StudioPage() {
-  return <NextStudio config={config} />
+  return (
+    <div style={{ inset: 0, position: "fixed", zIndex: 9999 }}>
+      <NextStudio config={config} />
+    </div>
+  );
 }


### PR DESCRIPTION
Render NextStudio inside a fixed, full-viewport div (style: inset:0, position:fixed, zIndex:9999) so the studio overlays the app and occupies the entire screen. Also normalize import/export quoting and formatting (no functional changes) and keep dynamic export as "force-static".