### PR TITLE
Remove tagType from Sanity schema

### DIFF
--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -1,19 +1,11 @@
 import { type SchemaTypeDefinition } from "sanity";
 
+import { authorType } from "./authorType";
 import { blockContentType } from "./blockContentType";
 import { categoryType } from "./categoryType";
 import { keywordType } from "./keywordType";
 import { postType } from "./postType";
-import { tagType } from "./tagType";
-import { authorType } from "./authorType";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [
-    blockContentType,
-    categoryType,
-    keywordType,
-    tagType,
-    postType,
-    authorType,
-  ],
+  types: [blockContentType, categoryType, keywordType, postType, authorType],
 };


### PR DESCRIPTION
Remove the unused tagType from the exported Sanity schema types and delete its import. Also tidy up import order (authorType moved) and compact the types array formatting; no other functional changes.