### PR TITLE
Add blog JSON download and PT-to-Markdown

### DIFF
--- a/src/app/blog/[slug]/download/route.ts
+++ b/src/app/blog/[slug]/download/route.ts
@@ -1,0 +1,62 @@
+import type { TypedObject } from "@portabletext/types";
+
+import { generateJsonContent } from "@/lib/portableTextToMarkdown";
+import { client } from "@/sanity/lib/client";
+
+type Post = {
+  _id: string;
+  body: TypedObject[];
+  categories: string[];
+  category: null | string;
+  mainImage: null | PostImage;
+  metaDescription: null | string;
+  metaKeywords: string[];
+  publishedAt: null | string;
+  subtitle: null | string;
+  tags: string[];
+  title: null | string;
+};
+
+type PostImage = {
+  alt?: null | string;
+  asset?: { _ref: string };
+};
+
+const QUERY = `
+  *[_type == "post" && slug.current == $slug][0] {
+    _id,
+    title,
+    subtitle,
+    metaDescription,
+    publishedAt,
+    mainImage,
+    body,
+    "slug": slug.current,
+    "category": categories[0]->title,
+    "categories": coalesce(categories[]->title, []),
+    "tags": coalesce(tags[]->title, []),
+    "metaKeywords": coalesce(metaKeywords[]->title, [])
+  }
+`;
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const post: null | Post = await client.fetch(QUERY, { slug });
+
+  if (!post) {
+    return new Response("Post not found", { status: 404 });
+  }
+
+  const json = generateJsonContent(post, slug);
+  const filename = `${slug}.json`;
+
+  return new Response(json, {
+    headers: {
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+  });
+}

--- a/src/lib/portableTextToMarkdown.ts
+++ b/src/lib/portableTextToMarkdown.ts
@@ -1,0 +1,137 @@
+import type { TypedObject } from "@portabletext/types";
+
+type PortableTextBlock = TypedObject & {
+  _type: string;
+  children?: Array<{
+    _type: string;
+    text?: string;
+    bold?: boolean;
+    italic?: boolean;
+    code?: boolean;
+    marks?: string[];
+  }>;
+  style?: string;
+  level?: number;
+  listItem?: string;
+};
+
+type PortableTextImage = TypedObject & {
+  _type: "image";
+  asset?: {
+    _ref: string;
+  };
+  alt?: string;
+};
+
+type PortableTextCode = TypedObject & {
+  _type: "code";
+  code?: string;
+  language?: string;
+};
+
+function serializeChildren(
+  children: PortableTextBlock["children"] = [],
+): string {
+  return children
+    .map((child) => {
+      let text = child.text || "";
+
+      if (child.bold) text = `**${text}**`;
+      if (child.italic) text = `*${text}*`;
+      if (child.code) text = `\`${text}\``;
+
+      return text;
+    })
+    .join("");
+}
+
+export function portableTextToMarkdown(body: TypedObject[]): string {
+  return body
+    .map((block) => {
+      const typedBlock = block as PortableTextBlock;
+
+      if (typedBlock._type === "block") {
+        const text = serializeChildren(typedBlock.children);
+        const style = typedBlock.style || "normal";
+
+        switch (style) {
+          case "h1":
+            return `# ${text}`;
+          case "h2":
+            return `## ${text}`;
+          case "h3":
+            return `### ${text}`;
+          case "h4":
+            return `#### ${text}`;
+          case "h5":
+            return `##### ${text}`;
+          case "h6":
+            return `###### ${text}`;
+          case "blockquote":
+            return `> ${text}`;
+          case "normal":
+          default:
+            if (typedBlock.listItem === "bullet") {
+              return `- ${text}`;
+            }
+            if (typedBlock.listItem === "number") {
+              return `1. ${text}`;
+            }
+            return text || "";
+        }
+      }
+
+      if (typedBlock._type === "image") {
+        const imageBlock = block as PortableTextImage;
+        const alt = imageBlock.alt || "Image";
+        const ref = imageBlock.asset?._ref || "";
+        return `![${alt}](image:${ref})`;
+      }
+
+      if (typedBlock._type === "code") {
+        const codeBlock = block as PortableTextCode;
+        const language = codeBlock.language || "";
+        const code = codeBlock.code || "";
+        return `\`\`\`${language}\n${code}\n\`\`\``;
+      }
+
+      return "";
+    })
+    .filter((block) => block.trim().length > 0)
+    .join("\n\n");
+}
+
+export function generateJsonContent(
+  post: {
+    title?: string | null;
+    subtitle?: string | null;
+    publishedAt?: string | null;
+    metaDescription?: string | null;
+    mainImage?: { alt?: string | null; asset?: { _ref: string } } | null;
+    categories?: string[];
+    tags?: string[];
+    metaKeywords?: string[];
+    body: TypedObject[];
+  },
+  slug: string,
+  author = "Ketan Rajpal",
+): string {
+  const bodyMarkdown = portableTextToMarkdown(post.body);
+
+  const content = {
+    title: post.title ?? null,
+    subtitle: post.subtitle ?? null,
+    slug,
+    author,
+    image: post.mainImage?.asset?._ref ?? null,
+    imageAlt: post.mainImage?.alt ?? null,
+    category: post.categories?.[0] ?? null,
+    tags: post.tags ?? [],
+    publishedAt: post.publishedAt ?? null,
+    metaDescription: post.metaDescription ?? null,
+    metaKeywords: post.metaKeywords ?? [],
+    body: bodyMarkdown,
+  };
+
+  return JSON.stringify(content, null, 2);
+}

--- a/src/sanity/lib/live.ts
+++ b/src/sanity/lib/live.ts
@@ -2,7 +2,8 @@
 // Before using it, import and render "<SanityLive />" in your layout, see
 // https://github.com/sanity-io/next-sanity#live-content-api for more information.
 import { defineLive } from "next-sanity/live";
-import { client } from './client'
+
+import { client } from "./client";
 
 export const { sanityFetch, SanityLive } = defineLive({
   client,


### PR DESCRIPTION
Add a GET route /blog/[slug]/download that fetches a post by slug from Sanity and returns a downloadable JSON file. Introduce src/lib/portableTextToMarkdown.ts with portableTextToMarkdown to convert Portable Text to Markdown and generateJsonContent to build the JSON payload (title, slug, author, image refs, tags, meta, and body). Also apply a trivial import formatting fix in src/sanity/lib/live.ts.