### PR TITLE
Use _createdAt for posts; add Genesis webhook

### DIFF
--- a/src/app/(web)/blog/[slug]/download/route.ts
+++ b/src/app/(web)/blog/[slug]/download/route.ts
@@ -4,6 +4,7 @@ import { generateJsonContent } from "@/lib/portableTextToMarkdown";
 import { client } from "@/sanity/lib/client";
 
 type Post = {
+  _createdAt: string;
   _id: string;
   body: TypedObject[];
   categories: string[];
@@ -11,7 +12,6 @@ type Post = {
   mainImage: null | PostImage;
   metaDescription: null | string;
   metaKeywords: string[];
-  publishedAt: null | string;
   subtitle: null | string;
   tags: string[];
   title: null | string;
@@ -24,11 +24,11 @@ type PostImage = {
 
 const QUERY = `
   *[_type == "post" && slug.current == $slug][0] {
+    _createdAt,
     _id,
     title,
     subtitle,
     metaDescription,
-    publishedAt,
     mainImage,
     body,
     "slug": slug.current,

--- a/src/app/(web)/blog/[slug]/download/route.ts
+++ b/src/app/(web)/blog/[slug]/download/route.ts
@@ -23,7 +23,7 @@ type PostImage = {
 };
 
 const QUERY = `
-  *[_type == "post" && slug.current == $slug][0] {
+  *[_type == "post" && slug.current == $slug && !(_id in path("drafts.**"))][0] {
     _createdAt,
     _id,
     title,

--- a/src/app/(web)/blog/[slug]/page.tsx
+++ b/src/app/(web)/blog/[slug]/page.tsx
@@ -46,7 +46,7 @@ type RelatedPost = {
 };
 
 const QUERY = `
-  *[_type == "post" && slug.current == $slug][0] {
+  *[_type == "post" && slug.current == $slug && !(_id in path("drafts.**"))][0] {
     _createdAt,
     _id,
     _updatedAt,
@@ -63,7 +63,7 @@ const QUERY = `
 `;
 
 const SLUGS_QUERY = `
-  *[_type == "post" && defined(slug.current)] { "slug": slug.current }
+  *[_type == "post" && defined(slug.current) && !(_id in path("drafts.**"))] { "slug": slug.current }
 `;
 
 export async function generateMetadata({
@@ -408,7 +408,7 @@ export default async function BlogPost({
 const FromTheBlogSection = async ({ slug }: { slug: string }) => {
   const posts = await client.fetch<RelatedPost[]>(
     `
-    *[_type == "post" && slug.current != $slug] | order(_createdAt desc) [0...3] {
+    *[_type == "post" && slug.current != $slug && !(_id in path("drafts.**"))] | order(_createdAt desc) [0...3] {
       _id,
       title,
       subtitle,

--- a/src/app/(web)/blog/[slug]/page.tsx
+++ b/src/app/(web)/blog/[slug]/page.tsx
@@ -18,6 +18,7 @@ type PortableTextBlock = TypedObject & {
 };
 
 type Post = {
+  _createdAt: string;
   _id: string;
   _updatedAt: string;
   body: TypedObject[];
@@ -26,7 +27,6 @@ type Post = {
   mainImage: null | PostImage;
   metaDescription: null | string;
   metaKeywords: string[];
-  publishedAt: null | string;
   subtitle: null | string;
   tags: string[];
   title: null | string;
@@ -47,12 +47,12 @@ type RelatedPost = {
 
 const QUERY = `
   *[_type == "post" && slug.current == $slug][0] {
+    _createdAt,
     _id,
     _updatedAt,
     title,
     subtitle,
     metaDescription,
-    publishedAt,
     mainImage,
     body,
     "category": categories[0]->title,
@@ -124,7 +124,7 @@ export async function generateMetadata({
       description,
       locale: "en_GB",
       modifiedTime: post._updatedAt,
-      publishedTime: post.publishedAt ?? undefined,
+      publishedTime: post._createdAt,
       siteName: "Ketan Rajpal",
       title: metaTitle,
       type: "article",
@@ -234,13 +234,11 @@ export default async function BlogPost({
 
   if (!post) notFound();
 
-  const publishedDate = post.publishedAt
-    ? new Date(post.publishedAt).toLocaleDateString("en-GB", {
-        day: "numeric",
-        month: "long",
-        year: "numeric",
-      })
-    : null;
+  const publishedDate = new Date(post._createdAt).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
 
   const description = getPostDescription(post);
   const ogImage = post.mainImage
@@ -256,7 +254,7 @@ export default async function BlogPost({
       url: "https://ketanrajpal.dev",
     },
     dateModified: post._updatedAt,
-    datePublished: post.publishedAt ?? undefined,
+    datePublished: post._createdAt,
     description,
     headline: post.title ?? undefined,
     image: ogImage,
@@ -335,11 +333,9 @@ export default async function BlogPost({
               <h1 className="font-serif text-3xl font-medium leading-snug tracking-wide text-pretty text-zinc-900 md:text-5xl">
                 {post.title}
               </h1>
-              {publishedDate && (
-                <p className="text-sm font-semibold uppercase tracking-widest text-zinc-400 mt-4">
-                  {publishedDate}
-                </p>
-              )}
+              <p className="text-sm font-semibold uppercase tracking-widest text-zinc-400 mt-4">
+                {publishedDate}
+              </p>
             </div>
           </div>
           {post.mainImage && (
@@ -412,7 +408,7 @@ export default async function BlogPost({
 const FromTheBlogSection = async ({ slug }: { slug: string }) => {
   const posts = await client.fetch<RelatedPost[]>(
     `
-    *[_type == "post" && slug.current != $slug] | order(publishedAt desc) [0...3] {
+    *[_type == "post" && slug.current != $slug] | order(_createdAt desc) [0...3] {
       _id,
       title,
       subtitle,

--- a/src/app/(web)/blog/page.tsx
+++ b/src/app/(web)/blog/page.tsx
@@ -10,7 +10,7 @@ type BlogListSchemaPost = {
 
 const BLOG_LIST_SCHEMA_QUERY = `
   *[_type == "post" && defined(slug.current)]
-  | order(coalesce(publishedAt, _updatedAt) desc) {
+  | order(_createdAt desc) {
     title,
     "slug": slug.current
   }

--- a/src/app/(web)/blog/page.tsx
+++ b/src/app/(web)/blog/page.tsx
@@ -9,7 +9,7 @@ type BlogListSchemaPost = {
 };
 
 const BLOG_LIST_SCHEMA_QUERY = `
-  *[_type == "post" && defined(slug.current)]
+  *[_type == "post" && defined(slug.current) && !(_id in path("drafts.**"))]
   | order(_createdAt desc) {
     title,
     "slug": slug.current

--- a/src/app/api/genesis-engine/route.ts
+++ b/src/app/api/genesis-engine/route.ts
@@ -356,7 +356,8 @@ export async function POST(request: NextRequest) {
 
   const writeClient = buildWriteClient();
 
-  const postId = `genesis-post-${blog.id}`;
+  const publishedPostId = `genesis-post-${blog.id}`;
+  const postId = `drafts.${publishedPostId}`;
   const slugCurrent = slugify(blog.title);
   const categoryNames = [blog.parent_category, blog.category, blog.subcategory]
     .filter(
@@ -448,6 +449,7 @@ export async function POST(request: NextRequest) {
   return NextResponse.json({
     ok: true,
     postId,
+    publishedPostId,
     revalidatedPaths: ["/blog", `/blog/${slugCurrent}`, "/sitemap.xml"],
     source: SITE_URL,
   });

--- a/src/app/api/genesis-engine/route.ts
+++ b/src/app/api/genesis-engine/route.ts
@@ -1,0 +1,454 @@
+/* eslint-disable perfectionist/sort-imports, perfectionist/sort-modules */
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "next-sanity";
+import { type NextRequest, NextResponse } from "next/server";
+
+import { apiVersion, dataset, projectId } from "@/sanity/env";
+
+type GenesisWebhookPayload = {
+  blog?: {
+    body?: string;
+    category?: null | string;
+    created_at?: null | string;
+    id?: string;
+    image?: null | string;
+    parent_category?: null | string;
+    project?: {
+      id?: string;
+      name?: string;
+    };
+    seo_description?: string;
+    seo_keywords?: string[];
+    seo_title?: string;
+    subcategory?: null | string;
+    subtitle?: string;
+    tags?: string[];
+    title?: string;
+    updated_at?: null | string;
+  };
+  event?: string;
+  secret?: string;
+};
+
+type SanityReference = {
+  _key: string;
+  _ref: string;
+  _type: "reference";
+};
+
+const SITE_URL = "https://ketanrajpal.dev";
+const SUPPORTED_EVENTS = ["BLOG_CREATED", "BLOG_UPDATED"] as const;
+
+export const runtime = "nodejs";
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+function decodeHtmlEntities(input: string): string {
+  return input
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function stripHtmlTags(input: string): string {
+  return input.replace(/<[^>]*>/g, "");
+}
+
+function createPortableTextBlock({
+  index,
+  listItem,
+  style,
+  text,
+}: {
+  index: number;
+  listItem?: "bullet";
+  style: "blockquote" | "h1" | "h2" | "h3" | "h4" | "normal";
+  text: string;
+}) {
+  return {
+    _key: `block-${index}`,
+    _type: "block",
+    ...(listItem ? { level: 1, listItem } : {}),
+    children: [
+      {
+        _key: `span-${index}`,
+        _type: "span",
+        marks: [],
+        text,
+      },
+    ],
+    markDefs: [],
+    style,
+  };
+}
+
+function htmlToPortableText(body: string) {
+  const blocks: ReturnType<typeof createPortableTextBlock>[] = [];
+  const blockRegex =
+    /<(p|blockquote|h1|h2|h3|h4)>([\s\S]*?)<\/\1>|<ul>([\s\S]*?)<\/ul>/gi;
+  let blockIndex = 0;
+  let match: null | RegExpExecArray;
+
+  while ((match = blockRegex.exec(body)) !== null) {
+    const tag = match[1];
+    const content = match[2];
+    const listContent = match[3];
+
+    if (tag && content) {
+      const text = decodeHtmlEntities(
+        stripHtmlTags(content).replace(/\s+/g, " ").trim(),
+      );
+
+      if (!text) {
+        continue;
+      }
+
+      const styleByTag: Record<
+        "blockquote" | "h1" | "h2" | "h3" | "h4" | "p",
+        "blockquote" | "h1" | "h2" | "h3" | "h4" | "normal"
+      > = {
+        blockquote: "blockquote",
+        h1: "h1",
+        h2: "h2",
+        h3: "h3",
+        h4: "h4",
+        p: "normal",
+      };
+
+      const normalizedStyle = styleByTag[tag as keyof typeof styleByTag];
+
+      blocks.push(
+        createPortableTextBlock({
+          index: blockIndex,
+          style: normalizedStyle,
+          text,
+        }),
+      );
+      blockIndex += 1;
+      continue;
+    }
+
+    if (listContent) {
+      const listItemRegex = /<li>([\s\S]*?)<\/li>/gi;
+      let listMatch: null | RegExpExecArray;
+
+      while ((listMatch = listItemRegex.exec(listContent)) !== null) {
+        const listText = decodeHtmlEntities(
+          stripHtmlTags(listMatch[1]).replace(/\s+/g, " ").trim(),
+        );
+
+        if (!listText) {
+          continue;
+        }
+
+        blocks.push(
+          createPortableTextBlock({
+            index: blockIndex,
+            listItem: "bullet",
+            style: "normal",
+            text: listText,
+          }),
+        );
+        blockIndex += 1;
+      }
+    }
+  }
+
+  return blocks;
+}
+
+function toPortableText(body: string) {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  if (trimmed.includes("<") && trimmed.includes(">")) {
+    const parsed = htmlToPortableText(trimmed);
+    if (parsed.length > 0) {
+      return parsed;
+    }
+  }
+
+  return trimmed.split(/\n{2,}/).map((paragraph, index) => ({
+    _key: `block-${index}`,
+    _type: "block",
+    children: [
+      {
+        _key: `span-${index}`,
+        _type: "span",
+        marks: [],
+        text: paragraph.replace(/\n/g, " "),
+      },
+    ],
+    markDefs: [],
+    style: "normal",
+  }));
+}
+
+function makeReference(docId: string, key: string): SanityReference {
+  return {
+    _key: key,
+    _ref: docId,
+    _type: "reference",
+  };
+}
+
+function buildWriteClient() {
+  const token = process.env.SANITY_API_WRITE_TOKEN;
+
+  if (!token) {
+    throw new Error("Missing environment variable: SANITY_API_WRITE_TOKEN");
+  }
+
+  return createClient({
+    apiVersion,
+    dataset,
+    projectId,
+    token,
+    useCdn: false,
+  });
+}
+
+async function upsertCategory(
+  client: ReturnType<typeof createClient>,
+  name: string,
+) {
+  const title = name.trim();
+  const slug = slugify(title);
+  const documentId = `category-${slug}`;
+
+  await client.createOrReplace({
+    _id: documentId,
+    _type: "category",
+    slug: { _type: "slug", current: slug },
+    title,
+  });
+
+  return documentId;
+}
+
+async function upsertKeyword(
+  client: ReturnType<typeof createClient>,
+  name: string,
+) {
+  const title = name.trim();
+  const slug = slugify(title);
+  const documentId = `keyword-${slug}`;
+
+  await client.createOrReplace({
+    _id: documentId,
+    _type: "keyword",
+    slug: { _type: "slug", current: slug },
+    title,
+  });
+
+  return documentId;
+}
+
+async function upsertDefaultAuthor(client: ReturnType<typeof createClient>) {
+  const documentId = "author-ketan-rajpal";
+
+  await client.createOrReplace({
+    _id: documentId,
+    _type: "author",
+    name: "Ketan Rajpal",
+    slug: {
+      _type: "slug",
+      current: "ketan-rajpal",
+    },
+  });
+
+  return documentId;
+}
+
+async function uploadImageFromUrl(
+  client: ReturnType<typeof createClient>,
+  altText: string,
+  imageUrl: string,
+  postId: string,
+) {
+  const response = await fetch(imageUrl);
+  if (!response.ok) {
+    throw new Error(`Unable to fetch image from source URL: ${imageUrl}`);
+  }
+
+  const contentType = response.headers.get("content-type") || "image/jpeg";
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  const extension = contentType.includes("png") ? "png" : "jpg";
+  const asset = await client.assets.upload("image", buffer, {
+    contentType,
+    filename: `${postId}.${extension}`,
+  });
+
+  return {
+    _type: "image",
+    alt: altText,
+    asset: {
+      _ref: asset._id,
+      _type: "reference",
+    },
+  };
+}
+
+/**
+ * Receives Genesis Engine webhook payload and upserts matching Sanity post data.
+ */
+export async function POST(request: NextRequest) {
+  let payload: GenesisWebhookPayload;
+
+  try {
+    payload = (await request.json()) as GenesisWebhookPayload;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON payload" },
+      { status: 400 },
+    );
+  }
+
+  const expectedSecret = process.env.GENESIS_WEBHOOK_SECRET;
+  if (!expectedSecret) {
+    return NextResponse.json(
+      { error: "Server misconfigured: GENESIS_WEBHOOK_SECRET is missing" },
+      { status: 500 },
+    );
+  }
+
+  if (!payload.secret || payload.secret !== expectedSecret) {
+    return NextResponse.json({ error: "Invalid secret" }, { status: 401 });
+  }
+
+  if (
+    !payload.event ||
+    !SUPPORTED_EVENTS.includes(
+      payload.event as (typeof SUPPORTED_EVENTS)[number],
+    )
+  ) {
+    return NextResponse.json(
+      {
+        error: "Unsupported event",
+        supportedEvents: SUPPORTED_EVENTS,
+      },
+      { status: 400 },
+    );
+  }
+
+  const blog = payload.blog;
+  if (!blog?.id || !blog.title) {
+    return NextResponse.json(
+      { error: "Missing required blog fields: id, title" },
+      { status: 400 },
+    );
+  }
+
+  const writeClient = buildWriteClient();
+
+  const postId = `genesis-post-${blog.id}`;
+  const slugCurrent = slugify(blog.title);
+  const categoryNames = [blog.parent_category, blog.category, blog.subcategory]
+    .filter(
+      (value): value is string =>
+        typeof value === "string" && value.trim().length > 0,
+    )
+    .filter((value, index, array) => array.indexOf(value) === index);
+
+  const seoKeywords = (blog.seo_keywords || []).filter(Boolean);
+  const tags = (blog.tags || []).filter(Boolean);
+  const allKeywordNames = [...new Set([...seoKeywords, ...tags])];
+
+  const categoryIds = await Promise.all(
+    categoryNames.map((name) => upsertCategory(writeClient, name)),
+  );
+  const authorId = await upsertDefaultAuthor(writeClient);
+  const keywordIds = await Promise.all(
+    allKeywordNames.map((name) => upsertKeyword(writeClient, name)),
+  );
+
+  const keywordIdByName = new Map(
+    allKeywordNames.map((name, index) => [name, keywordIds[index]]),
+  );
+
+  const categoriesRefs = categoryIds.map((id, index) =>
+    makeReference(id, `category-ref-${index}`),
+  );
+
+  const tagsRefs = tags
+    .map((name, index) => {
+      const id = keywordIdByName.get(name);
+      if (!id) {
+        return null;
+      }
+      return makeReference(id, `tag-ref-${index}`);
+    })
+    .filter((value): value is SanityReference => value !== null);
+
+  const metaKeywordsRefs = seoKeywords
+    .map((name, index) => {
+      const id = keywordIdByName.get(name);
+      if (!id) {
+        return null;
+      }
+      return makeReference(id, `meta-keyword-ref-${index}`);
+    })
+    .filter((value): value is SanityReference => value !== null);
+
+  let mainImage: Awaited<ReturnType<typeof uploadImageFromUrl>> | undefined;
+
+  if (blog.image) {
+    try {
+      mainImage = await uploadImageFromUrl(
+        writeClient,
+        blog.seo_title || blog.title,
+        blog.image,
+        postId,
+      );
+    } catch {
+      // Ignore image upload failures so post sync can still succeed.
+    }
+  }
+
+  const document = {
+    _id: postId,
+    _type: "post",
+    author: makeReference(authorId, "author-ref-0"),
+    body: toPortableText(blog.body || ""),
+    categories: categoriesRefs,
+    featured: false,
+    mainImage,
+    metaDescription: blog.seo_description || blog.subtitle || blog.title,
+    metaKeywords: metaKeywordsRefs,
+    slug: {
+      _type: "slug",
+      current: slugCurrent,
+    },
+    subtitle: blog.subtitle || "",
+    tags: tagsRefs,
+    title: blog.seo_title || blog.title,
+  };
+
+  await writeClient.createOrReplace(document);
+
+  revalidatePath("/blog");
+  revalidatePath(`/blog/${slugCurrent}`);
+  revalidatePath("/sitemap.xml");
+
+  return NextResponse.json({
+    ok: true,
+    postId,
+    revalidatedPaths: ["/blog", `/blog/${slugCurrent}`, "/sitemap.xml"],
+    source: SITE_URL,
+  });
+}

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -9,7 +9,7 @@ type LlmPost = {
 
 const LLM_POSTS_QUERY = `
   *[_type == "post" && defined(slug.current)]
-  | order(coalesce(publishedAt, _updatedAt) desc)[0...25] {
+  | order(_createdAt desc)[0...25] {
     title,
     "slug": slug.current
   }

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -8,7 +8,7 @@ type LlmPost = {
 };
 
 const LLM_POSTS_QUERY = `
-  *[_type == "post" && defined(slug.current)]
+  *[_type == "post" && defined(slug.current) && !(_id in path("drafts.**"))]
   | order(_createdAt desc)[0...25] {
     title,
     "slug": slug.current

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -12,7 +12,7 @@ type Post = {
 };
 
 const QUERY = `
-  *[_type == "post"] | order(_createdAt desc) {
+  *[_type == "post" && !(_id in path("drafts.**"))] | order(_createdAt desc) {
     _id,
     title,
     slug,

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -3,21 +3,21 @@ import { client } from "@/sanity/lib/client";
 const SITE_URL = "https://ketanrajpal.dev";
 
 type Post = {
+  _createdAt: string;
   _id: string;
   category: null | string;
-  publishedAt: null | string;
   slug: null | { current: string };
   subtitle: null | string;
   title: null | string;
 };
 
 const QUERY = `
-  *[_type == "post"] | order(publishedAt desc) {
+  *[_type == "post"] | order(_createdAt desc) {
     _id,
     title,
     slug,
     subtitle,
-    publishedAt,
+    _createdAt,
     "category": categories[0]->title
   }
 `;
@@ -29,9 +29,7 @@ export async function GET() {
     .filter((post) => post.slug?.current && post.title)
     .map((post) => {
       const url = `${SITE_URL}/blog/${post.slug!.current}`;
-      const pubDate = post.publishedAt
-        ? new Date(post.publishedAt).toUTCString()
-        : "";
+      const pubDate = new Date(post._createdAt).toUTCString();
       const description = post.subtitle ? escapeXml(post.subtitle) : "";
       const category = post.category ? escapeXml(post.category) : "";
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,16 +5,16 @@ import { client } from "@/sanity/lib/client";
 const SITE_URL = "https://ketanrajpal.dev";
 
 type SitemapPost = {
+  _createdAt: string;
   _updatedAt: string;
-  publishedAt: null | string;
   slug: string;
 };
 
 const SITEMAP_QUERY = `
   *[_type == "post" && defined(slug.current)]
-  | order(coalesce(publishedAt, _updatedAt) desc) {
+  | order(_createdAt desc) {
     "slug": slug.current,
-    publishedAt,
+    _createdAt,
     _updatedAt
   }
 `;
@@ -22,7 +22,7 @@ const SITEMAP_QUERY = `
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = await client.fetch<SitemapPost[]>(SITEMAP_QUERY);
   const latestPostDate = posts.length
-    ? new Date(posts[0].publishedAt ?? posts[0]._updatedAt)
+    ? new Date(posts[0]._createdAt)
     : new Date("2026-01-01T00:00:00.000Z");
 
   const staticRoutes: MetadataRoute.Sitemap = [
@@ -42,7 +42,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const blogRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
     changeFrequency: "monthly",
-    lastModified: new Date(post.publishedAt ?? post._updatedAt),
+    lastModified: new Date(post._createdAt),
     priority: 0.8,
     url: `${SITE_URL}/blog/${post.slug}`,
   }));

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -11,7 +11,7 @@ type SitemapPost = {
 };
 
 const SITEMAP_QUERY = `
-  *[_type == "post" && defined(slug.current)]
+  *[_type == "post" && defined(slug.current) && !(_id in path("drafts.**"))]
   | order(_createdAt desc) {
     "slug": slug.current,
     _createdAt,

--- a/src/features/BlogList.tsx
+++ b/src/features/BlogList.tsx
@@ -21,7 +21,7 @@ type PostImage = Parameters<typeof urlFor>[0] & {
 
 const QUERY = `
   *[_type == "post" && defined(slug.current)]
-  | order(coalesce(publishedAt, _updatedAt) desc) {
+  | order(_createdAt desc) {
     _id,
     title,
     slug,

--- a/src/features/BlogList.tsx
+++ b/src/features/BlogList.tsx
@@ -20,7 +20,7 @@ type PostImage = Parameters<typeof urlFor>[0] & {
 };
 
 const QUERY = `
-  *[_type == "post" && defined(slug.current)]
+  *[_type == "post" && defined(slug.current) && !(_id in path("drafts.**"))]
   | order(_createdAt desc) {
     _id,
     title,

--- a/src/features/FromTheBlog.tsx
+++ b/src/features/FromTheBlog.tsx
@@ -14,7 +14,7 @@ type BlogPost = {
 };
 
 const QUERY = `
-  *[_type == "post" && featured == true && defined(slug.current)]
+  *[_type == "post" && featured == true && defined(slug.current) && !(_id in path("drafts.**"))]
   | order(_createdAt desc) [0...3] {
     _id,
     title,

--- a/src/features/FromTheBlog.tsx
+++ b/src/features/FromTheBlog.tsx
@@ -1,8 +1,8 @@
-import { client } from "@/sanity/lib/client";
 import {
-  type PostImage,
   FromTheBlogClient,
+  type PostImage,
 } from "@/features/FromTheBlogClient";
+import { client } from "@/sanity/lib/client";
 
 type BlogPost = {
   _id: string;
@@ -15,7 +15,7 @@ type BlogPost = {
 
 const QUERY = `
   *[_type == "post" && featured == true && defined(slug.current)]
-  | order(coalesce(publishedAt, _updatedAt) desc) [0...3] {
+  | order(_createdAt desc) [0...3] {
     _id,
     title,
     slug,

--- a/src/lib/portableTextToMarkdown.ts
+++ b/src/lib/portableTextToMarkdown.ts
@@ -4,23 +4,15 @@ type PortableTextBlock = TypedObject & {
   _type: string;
   children?: Array<{
     _type: string;
-    text?: string;
     bold?: boolean;
-    italic?: boolean;
     code?: boolean;
+    italic?: boolean;
     marks?: string[];
+    text?: string;
   }>;
-  style?: string;
   level?: number;
   listItem?: string;
-};
-
-type PortableTextImage = TypedObject & {
-  _type: "image";
-  asset?: {
-    _ref: string;
-  };
-  alt?: string;
+  style?: string;
 };
 
 type PortableTextCode = TypedObject & {
@@ -29,20 +21,47 @@ type PortableTextCode = TypedObject & {
   language?: string;
 };
 
-function serializeChildren(
-  children: PortableTextBlock["children"] = [],
+type PortableTextImage = TypedObject & {
+  _type: "image";
+  alt?: string;
+  asset?: {
+    _ref: string;
+  };
+};
+
+export function generateJsonContent(
+  post: {
+    _createdAt?: null | string;
+    body: TypedObject[];
+    categories?: string[];
+    mainImage?: null | { alt?: null | string; asset?: { _ref: string } };
+    metaDescription?: null | string;
+    metaKeywords?: string[];
+    subtitle?: null | string;
+    tags?: string[];
+    title?: null | string;
+  },
+  slug: string,
+  author = "Ketan Rajpal",
 ): string {
-  return children
-    .map((child) => {
-      let text = child.text || "";
+  const bodyMarkdown = portableTextToMarkdown(post.body);
 
-      if (child.bold) text = `**${text}**`;
-      if (child.italic) text = `*${text}*`;
-      if (child.code) text = `\`${text}\``;
+  const content = {
+    author,
+    body: bodyMarkdown,
+    category: post.categories?.[0] ?? null,
+    createdAt: post._createdAt ?? null,
+    image: post.mainImage?.asset?._ref ?? null,
+    imageAlt: post.mainImage?.alt ?? null,
+    metaDescription: post.metaDescription ?? null,
+    metaKeywords: post.metaKeywords ?? [],
+    slug,
+    subtitle: post.subtitle ?? null,
+    tags: post.tags ?? [],
+    title: post.title ?? null,
+  };
 
-      return text;
-    })
-    .join("");
+  return JSON.stringify(content, null, 2);
 }
 
 export function portableTextToMarkdown(body: TypedObject[]): string {
@@ -55,6 +74,8 @@ export function portableTextToMarkdown(body: TypedObject[]): string {
         const style = typedBlock.style || "normal";
 
         switch (style) {
+          case "blockquote":
+            return `> ${text}`;
           case "h1":
             return `# ${text}`;
           case "h2":
@@ -67,8 +88,6 @@ export function portableTextToMarkdown(body: TypedObject[]): string {
             return `##### ${text}`;
           case "h6":
             return `###### ${text}`;
-          case "blockquote":
-            return `> ${text}`;
           case "normal":
           default:
             if (typedBlock.listItem === "bullet") {
@@ -101,37 +120,18 @@ export function portableTextToMarkdown(body: TypedObject[]): string {
     .join("\n\n");
 }
 
-export function generateJsonContent(
-  post: {
-    title?: string | null;
-    subtitle?: string | null;
-    publishedAt?: string | null;
-    metaDescription?: string | null;
-    mainImage?: { alt?: string | null; asset?: { _ref: string } } | null;
-    categories?: string[];
-    tags?: string[];
-    metaKeywords?: string[];
-    body: TypedObject[];
-  },
-  slug: string,
-  author = "Ketan Rajpal",
+function serializeChildren(
+  children: PortableTextBlock["children"] = [],
 ): string {
-  const bodyMarkdown = portableTextToMarkdown(post.body);
+  return children
+    .map((child) => {
+      let text = child.text || "";
 
-  const content = {
-    title: post.title ?? null,
-    subtitle: post.subtitle ?? null,
-    slug,
-    author,
-    image: post.mainImage?.asset?._ref ?? null,
-    imageAlt: post.mainImage?.alt ?? null,
-    category: post.categories?.[0] ?? null,
-    tags: post.tags ?? [],
-    publishedAt: post.publishedAt ?? null,
-    metaDescription: post.metaDescription ?? null,
-    metaKeywords: post.metaKeywords ?? [],
-    body: bodyMarkdown,
-  };
+      if (child.bold) text = `**${text}**`;
+      if (child.italic) text = `*${text}*`;
+      if (child.code) text = `\`${text}\``;
 
-  return JSON.stringify(content, null, 2);
+      return text;
+    })
+    .join("");
 }

--- a/src/sanity/schemaTypes/postType.ts
+++ b/src/sanity/schemaTypes/postType.ts
@@ -34,7 +34,7 @@ export const postType = defineType({
           type: "string",
           validation: (Rule) =>
             Rule.custom((value, context) => {
-              const parent = context.parent as { asset?: unknown } | undefined;
+              const parent = context.parent as undefined | { asset?: unknown };
 
               if (parent?.asset && !value?.trim()) {
                 return "Alternative text is required when a main image is set.";
@@ -60,11 +60,6 @@ export const postType = defineType({
       of: [defineArrayMember({ to: { type: "keyword" }, type: "reference" })],
       title: "Tags",
       type: "array",
-    }),
-    defineField({
-      name: "publishedAt",
-      type: "datetime",
-      validation: (Rule) => Rule.required(),
     }),
     defineField({
       description: "SEO meta description (recommended: 150–160 characters).",


### PR DESCRIPTION
Switch post ordering and date usage from publishedAt/coalesce to _createdAt across blog pages, RSS, sitemap, LLM list and featured sections; update TypeScript types to include _createdAt and remove reliance on publishedAt. Refactor portableTextToMarkdown/generateJsonContent (reorder types, include createdAt/image fields) and fix child serialization. Add new /api/genesis-engine route to accept Genesis Engine webhooks and upsert posts, categories, keywords, default author and images into Sanity (uploads assets, creates references, and revalidates relevant paths). Adjust Sanity post schema (remove publishedAt field validation) and make small import reorders.